### PR TITLE
Properly fixes a problem that was "fixed" with commit f68f058

### DIFF
--- a/pe.lua
+++ b/pe.lua
@@ -182,7 +182,7 @@ ProbablyEngine.condition.register("spell.regen", function(target, spell)
   return cast_time_in_seconds * cur_regen
 end)
 
-ProbablyEngine.condition.register("spell.casttime", function(target, spell)
+ProbablyEngine.condition.register("casttime", function(target, spell)
     local name, rank, icon, cast_time, min_range, max_range = GetSpellInfo(spell)
     return cast_time
 end)


### PR DESCRIPTION
Having it as spell.casttime was returning false for some reason but changing it to just casttime fixed the error.
